### PR TITLE
Add butterworth filtered aperture functions and phase offset correction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     additional:
         strategy:
             matrix:
-                envs: ["docs-check"]  # add "numba_coverage" once there are tests marked with that
+                envs: ["docs-check", "numba_coverage"]
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,17 @@ license-files = { paths = ["LICENSE"] }
 dependencies = [
     "libertem",
     "numpy",
+    # Minimum constraints of numba for all Python versions we support
+    # See https://numba.readthedocs.io/en/stable/release-notes-overview.html
+    "numba>=0.53;python_version < '3.10'",
+    "numba>=0.55;python_version < '3.11'",
+    "numba>=0.57;python_version < '3.12'",
+    "numba>=0.59;python_version < '3.13'",
+    "numba>=0.61;python_version < '3.14' and python_version >= '3.10'",
+    # for any future Python release, constrain numba to a recent version,
+    # otherwise, version resolution might try to install an ancient version
+    # that isn't constrained properly:
+    "numba>=0.61;python_version >= '3.14'",  
     "scipy",
     "sparse",
     'scikit-image',

--- a/src/libertem_holo/base/filters.py
+++ b/src/libertem_holo/base/filters.py
@@ -374,25 +374,6 @@ def central_line_filter(
 
 
 @numba.njit
-def butterworth_disk(shape, radius, order=12):
-    """
-    shape: output shape of the aperture
-
-    radius: radius in pixels
-
-    order: order of the butterworth filter
-    """
-    result = np.zeros(shape, dtype=np.float32)
-    cy = shape[0]/2
-    cx = shape[1]/2
-    for y in range(shape[0]):
-        for x in range(shape[1]):
-            d = np.sqrt((y-cy)**2 + (x-cx)**2)
-            result[y, x] = 1/np.sqrt(1 + np.pow((d/radius), 2*order))
-    return result
-
-
-@numba.njit
 def butterworth_line(shape, width, sb_position, length_ratio=0.9, order=12):
     """
     shape: output shape of the aperture
@@ -424,7 +405,6 @@ def butterworth_line(shape, width, sb_position, length_ratio=0.9, order=12):
             y0 = y - cy
             d = y0 - c * x0
             xc = (d-c)/(a-b)
-            yc = a * xc + c
 
             if sb_sel * xc < 0:
                 dist = np.abs(a*x0 - y0 + b)/np.sqrt(a**2 + 1)

--- a/src/libertem_holo/base/filters.py
+++ b/src/libertem_holo/base/filters.py
@@ -432,4 +432,3 @@ def butterworth_line(shape, width, sb_position, length_ratio=0.9, order=12):
                 dist = np.sqrt((y-cy-1)**2 + (x-cx)**2)
             result[y, x] = 1/np.sqrt(1 + np.pow((dist/width), 2*order))
     return 1 - result
-

--- a/src/libertem_holo/base/reconstr.py
+++ b/src/libertem_holo/base/reconstr.py
@@ -389,7 +389,7 @@ def phase_offset_correction(
     wtype: Literal['weighted'] | Literal['unweighted'] = 'weighted',
     threshold: float = 1e-12,
     return_stack: bool = False,
-) -> tuple[np.ndarray, typing.Union[np.ndarray, None]]:
+) -> tuple[np.ndarray, np.ndarray | None]:
     """
     This part of the code is to correct for the phase drift in the holograms due
     to the biprism drift with time.  Since we are dealing with the phase of the

--- a/src/libertem_holo/base/reconstr.py
+++ b/src/libertem_holo/base/reconstr.py
@@ -396,13 +396,16 @@ def phase_offset_correction(
     image which wraps from -pi to pi a simple scalar correction of the phase
     doesnt work as the phase wraps around the phase axis. So the options for a
     solution would be either iterative solution which is computationally heavy
-    or an eign value solution which is implemented here.
+    or an eigenvalue solution which is implemented here.
 
     We start with a stack of holograms acquired using Holoworks or stack
     acquisition and this function returns a phase corrected complex image
+    and optionally a stack of the phase corrected complex images before
+    averaging.
 
-    Adapted from a function by oleh.melnyk; for more details, see
-    https://arxiv.org/pdf/2005.02032.pdf
+    Adapted from a function by oleh.melnyk:
+    https://github.com/Ptychography-4-0/ptychography/blob/master/src/ptychography40/stitching/stitching.py
+    for more details, see https://arxiv.org/pdf/2005.02032.pdf
 
     Parameters
     ----------

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -34,3 +34,31 @@ def test_get_phase(backend: str, holo_data) -> None:
 
     # TODO: ensure deterministic results for `get_phase`?
     # assert np.allclose(phase_ref[slice_crop][0, 0], phase[...], rtol=0.12)
+
+
+@pytest.mark.with_numba
+@pytest.mark.parametrize(
+    "backend", ["numpy", "cupy"],
+)
+@pytest.mark.parametrize(
+    "line_filter_width", [1, 10, None],
+)
+def test_params_from_hologram(backend: str, holo_data, line_filter_width) -> None:
+    holo, ref, phase_ref, slice_crop = holo_data
+
+    if backend == "cupy":
+        d = detect()
+        if not d["cudas"] or not d["has_cupy"]:
+            pytest.skip("No CUDA device or no CuPy, skipping CuPy test")
+        import cupy as cp
+        xp = cp
+    else:
+        xp = np
+
+    HoloParams.from_hologram(
+        ref[0, 0],
+        central_band_mask_radius=1,
+        out_shape=(32, 32),
+        line_filter_width=line_filter_width,
+        xp=xp,
+    )

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -25,8 +25,7 @@ def test_get_phase(backend: str, holo_data) -> None:
         ref[0, 0],
         central_band_mask_radius=1,
         out_shape=(32, 32),
-        line_filter_length=0.9,
-        line_filter_width=0,
+        line_filter_width=None,
         xp=xp,
     )
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -6,6 +6,7 @@ from libertem_holo.base.utils import HoloParams
 from libertem_holo.base.reconstr import get_phase
 
 
+@pytest.mark.with_numba
 @pytest.mark.parametrize(
     "backend", ["numpy", "cupy"],
 )


### PR DESCRIPTION
* Both disk and line filter; used by default with hopefully reasonable parameters when creating `HoloParams`.
* Add phase offset correction, which is needed to properly average complex images
* Tests are mostly smoke tests for now; we will need to develop a strategy how to handle some of the situations (one possibility would be to use `pytest-snapshot` or similar to make sure things don't break underneath us without noticing)

## Contributor Checklist:

* [ ] I have added myself to [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases

<!--

## Please remove this section

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
