### PR TITLE
Performance improvements (GPU; auxiliary functions)

### DIFF
--- a/benchmarks/test_bench_filters.py
+++ b/benchmarks/test_bench_filters.py
@@ -1,0 +1,90 @@
+import pytest
+import numpy as np
+
+from sparseconverter import for_backend, NUMPY
+from libertem.utils.devices import detect
+
+from libertem_holo.base.filters import (
+    butterworth_disk,
+    butterworth_line,
+    disk_aperture,
+)
+
+
+@pytest.mark.benchmark(
+    group="filters"
+)
+@pytest.mark.parametrize(
+    'backend', ['numpy', 'cupy'],
+)
+def test_butterworth_disk(backend, benchmark, lt_ctx):
+    if backend == 'cupy':
+        d = detect()
+        if not d['cudas'] or not d['has_cupy']:
+            pytest.skip("No CUDA device or no CuPy, skipping CuPy test")
+
+    if backend == 'cupy':
+        import cupy as xp
+    else:
+        xp = np
+
+    benchmark(
+        lambda: for_backend(
+            butterworth_disk(shape=(4096, 4096), radius=128.0, order=12, xp=xp),
+            NUMPY
+        )
+    )
+
+
+@pytest.mark.benchmark(
+    group="filters"
+)
+@pytest.mark.parametrize(
+    'backend', ['numpy', 'cupy'],
+)
+def test_butterworth_line(backend, benchmark, lt_ctx):
+    if backend == 'cupy':
+        d = detect()
+        if not d['cudas'] or not d['has_cupy']:
+            pytest.skip("No CUDA device or no CuPy, skipping CuPy test")
+
+    if backend == 'cupy':
+        import cupy as xp
+    else:
+        xp = np
+
+    benchmark(
+        lambda: for_backend(
+            butterworth_line(
+                shape=(4096, 4096),
+                width=3,
+                sb_position=(100.1, 100),
+                length_ratio=0.9,
+                order=12,
+                xp=xp
+            ),
+            NUMPY
+        )
+    )
+
+
+@pytest.mark.benchmark(
+    group="filters"
+)
+@pytest.mark.parametrize(
+    'backend', ['numpy', 'cupy'],
+)
+def test_disk_aperture(backend, benchmark, lt_ctx):
+    if backend == 'cupy':
+        d = detect()
+        if not d['cudas'] or not d['has_cupy']:
+            pytest.skip("No CUDA device or no CuPy, skipping CuPy test")
+
+    if backend == 'cupy':
+        import cupy as xp
+    else:
+        xp = np
+
+    benchmark(
+        lambda: disk_aperture(out_shape=(4096, 4096), radius=128.0, xp=xp),
+    )

--- a/benchmarks/test_bench_utils.py
+++ b/benchmarks/test_bench_utils.py
@@ -1,0 +1,32 @@
+import pytest
+import numpy as np
+
+from libertem.utils.devices import detect
+from libertem_holo.base.utils import HoloParams
+
+
+@pytest.mark.benchmark(
+    group="utils"
+)
+@pytest.mark.parametrize(
+    'backend', ['numpy', 'cupy'],
+)
+def test_params_from_hologram(backend, benchmark, lt_ctx, large_holo_data):
+    npy_path, ds = large_holo_data
+    holo = np.load(str(npy_path), mmap_mode='r')
+
+    if backend == 'cupy':
+        d = detect()
+        if not d['cudas'] or not d['has_cupy']:
+            pytest.skip("No CUDA device or no CuPy, skipping CuPy test")
+
+    if backend == 'cupy':
+        import cupy as xp
+    else:
+        xp = np
+
+    benchmark(
+        lambda: HoloParams.from_hologram(
+            holo[0, 0], central_band_mask_radius=100, xp=xp
+        ),
+    )

--- a/benchmarks/test_holo_stack.py
+++ b/benchmarks/test_holo_stack.py
@@ -35,7 +35,7 @@ def cpu_ctx():
 @pytest.mark.parametrize(
     'backend', ['numpy', 'cupy'],
 )
-def test_stack_reconstr_inline(backend, benchmark, lt_ctx, large_holo_data):
+def test_stack_reconstr(backend, benchmark, lt_ctx, large_holo_data):
     path, ds = large_holo_data
     if backend == 'cupy':
         d = detect()

--- a/benchmarks/test_holo_stack.py
+++ b/benchmarks/test_holo_stack.py
@@ -1,5 +1,6 @@
 import pytest
 
+from libertem.api import Context
 from libertem.utils.devices import detect
 from libertem.common.backend import set_use_cpu, set_use_cuda
 
@@ -12,7 +13,7 @@ from libertem_holo.udf import HoloReconstructUDF
 @pytest.mark.parametrize(
     'backend', ['numpy', 'cupy'],
 )
-def test_stack_reconstr(backend, benchmark, lt_ctx, large_holo_data):
+def test_stack_reconstr_inline(backend, benchmark, lt_ctx, large_holo_data):
     path, ds = large_holo_data
     if backend == 'cupy':
         d = detect()
@@ -32,3 +33,32 @@ def test_stack_reconstr(backend, benchmark, lt_ctx, large_holo_data):
         benchmark(lt_ctx.run_udf, udf=udf, dataset=ds)
     finally:
         set_use_cpu(0)
+
+
+@pytest.mark.benchmark(
+    group="stack"
+)
+@pytest.mark.parametrize(
+    'backend', ['numpy', 'cupy'],
+)
+@pytest.mark.parametrize(
+    'out_shape', [(1024, 1024), (512, 512), (256, 256)],
+)
+def test_stack_reconstr_parallel(backend, out_shape, benchmark, large_holo_data):
+    path, ds = large_holo_data
+    if backend == 'cupy':
+        d = detect()
+        if not d['cudas'] or not d['has_cupy']:
+            pytest.skip("No CUDA device or no CuPy, skipping CuPy test")
+        ctx = Context.make_with(gpus=1, cpus=0)
+    else:
+        ctx = Context.make_with(gpus=0)
+
+    with ctx:
+        udf = HoloReconstructUDF.with_default_aperture(
+            out_shape=out_shape,
+            sb_size=out_shape[0] - 32,
+            sb_position=(1024, 1024),
+            precision=True,
+        )
+        benchmark(ctx.run_udf, udf=udf, dataset=ds)

--- a/src/libertem_holo/base/filters.py
+++ b/src/libertem_holo/base/filters.py
@@ -93,12 +93,12 @@ def _butterworth_disk_kernel(y, x, cy, cx, radius, order):
     return 1/math.sqrt(1 + math.pow((d/radius), 2*order))
 
 
-@numba.njit(cache=True)
+@numba.njit(cache=True, parallel=True)
 def _butterworth_disk_cpu(shape: tuple[int, int], radius: float, order: int = 12):
     result = np.zeros(shape, dtype=np.float32)
     cy = shape[0]/2
     cx = shape[1]/2
-    for y in range(shape[0]):
+    for y in numba.prange(shape[0]):
         for x in range(shape[1]):
             result[y, x] = _butterworth_disk_kernel(y, x, cy, cx, radius, order)
     return result
@@ -452,13 +452,13 @@ def _butterworth_line_kernel(
     return 1 / math.sqrt(1 + math.pow((dist/width), 2*order))
 
 
-@numba.njit(cache=True)
+@numba.njit(cache=True, parallel=True)
 def _butterworth_line_cpu(shape, width, sb_position, length_ratio=0.9, order=12):
     result = np.zeros(shape, dtype=np.float32)
     cy = shape[0] / 2 - 1
     cx = shape[1] / 2 - 1
 
-    for y in range(shape[0]):
+    for y in numba.prange(shape[0]):
         for x in range(shape[1]):
             result[y, x] = _butterworth_line_kernel(
                 y, x, cy, cx,

--- a/src/libertem_holo/base/filters.py
+++ b/src/libertem_holo/base/filters.py
@@ -51,6 +51,24 @@ def disk_aperture(out_shape: tuple[int, int], radius: float, xp=np) -> np.ndarra
 
 
 def butterworth_disk(shape: tuple[int, int], radius: float, order: int = 12, xp=np):
+    """Generate a filered disk-shaped aperture.
+
+    The edges are filtered with a butterworth filter of the given order.
+
+    Parameters
+    ----------
+    shape
+        output shape of the aperture
+
+    radius
+        radius in pixels
+
+    order
+        order of the butterworth filter
+
+    xp
+        Either numpy or cupy
+    """
     if xp is np:
         return _butterworth_disk_cpu(shape, radius, order)
     else:
@@ -434,12 +452,23 @@ def butterworth_line(
     order: int = 12,
     xp=np
 ):
-    """
-    shape: output shape of the aperture
+    """Generate a line filter.
 
-    width: width of the line in pixels
+    This is useful to remove fresnel fringes.
 
-    order: order of the butterworth filter
+    Parameters
+    ----------
+    shape
+        output shape of the aperture
+
+    width
+        width of the line in pixels
+
+    order
+        order of the butterworth filter
+
+    xp
+        Either numpy or cupy
     """
     if xp is np:
         return _butterworth_line_cpu(

--- a/src/libertem_holo/base/generate.py
+++ b/src/libertem_holo/base/generate.py
@@ -8,7 +8,8 @@ def hologram_frame(amp, phi,
                    visibility=1.,
                    f_angle=30.,
                    gaussian_noise=None,
-                   poisson_noise=None):
+                   poisson_noise=None,
+                   xp=np):
     """
     Generates holograms using phase and amplitude as an input
 
@@ -56,23 +57,30 @@ def hologram_frame(amp, phi,
     if not amp.shape == phi.shape:
         raise ValueError('Amplitude and phase should be 2d arrays of the same shape.')
     sy, sx = phi.shape
-    x, y = np.meshgrid(np.arange(sx), np.arange(sy))
+    x, y = xp.meshgrid(xp.arange(sx), xp.arange(sy))
     f_angle = f_angle / 180. * np.pi
 
+    amp = xp.asarray(amp)
+    phi = xp.asarray(phi)
+
     holo = counts / 2 * (1. + amp ** 2 + 2. * amp * visibility
-                         * np.cos(2. * np.pi * y / sampling * np.cos(f_angle)
-                                  + 2. * np.pi * x / sampling * np.sin(f_angle)
+                         * xp.cos(2. * xp.pi * y / sampling * xp.cos(f_angle)
+                                  + 2. * xp.pi * x / sampling * xp.sin(f_angle)
                                   - phi))
 
     if poisson_noise:
         if not isinstance(poisson_noise, (float, int)):
             raise ValueError("poisson_noise parameter should be float or int or None.")
         noise_scale = poisson_noise * counts
-        holo = noise_scale * np.random.poisson(holo / noise_scale)
+        holo = noise_scale * xp.random.poisson(holo / noise_scale)
 
     if gaussian_noise:
         if not isinstance(gaussian_noise, (float, int)):
             raise ValueError("gaussian_noise parameter should be float or int or None.")
-        holo = gaussian_filter(holo, gaussian_noise)
+        if xp is not np:
+            from cupyx.scipy.ndimage import gaussian_filter as gaussian_filter_impl
+        else:
+            gaussian_filter_impl = gaussian_filter
+        holo = gaussian_filter_impl(holo, gaussian_noise)
 
     return holo

--- a/src/libertem_holo/base/utils.py
+++ b/src/libertem_holo/base/utils.py
@@ -91,7 +91,7 @@ def get_slice_fft(
 def _hard_disk_aperture(shape: tuple[int, int], radius: float, xp=np):
     cy = shape[0]//2
     cx = shape[1]//2
-    ys, xs = xp.meshgrid(xp.arange(shape[0]), xp.arange(shape[1]))
+    ys, xs = xp.meshgrid(xp.arange(shape[0]), xp.arange(shape[1]), indexing='ij')
     result = xp.zeros(shape, dtype=bool)
     result[np.sqrt((xs - cx)**2 + (ys - cy)**2) < radius] = 1
     return np.fft.fftshift(result)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -71,8 +71,8 @@ def test_butterworth_disk_cpu_gpu_equiv():
         pytest.skip("No CUDA device or no CuPy, skipping CuPy test")
 
     import cupy as cp
-    disk_gpu = butterworth_disk(shape=(512, 512), radius=128.0, order=12, xp=cp)
-    disk_cpu = butterworth_disk(shape=(512, 512), radius=128.0, order=12, xp=np)
+    disk_gpu = butterworth_disk(shape=(512, 511), radius=128.0, order=12, xp=cp)
+    disk_cpu = butterworth_disk(shape=(512, 511), radius=128.0, order=12, xp=np)
 
     assert np.allclose(disk_gpu.get(), disk_cpu)
 
@@ -85,7 +85,7 @@ def test_butterworth_line_cpu_gpu_equiv():
     import cupy as cp
 
     line_cpu = butterworth_line(
-        shape=(512, 512),
+        shape=(512, 511),
         width=3,
         sb_position=(100.1, 100),
         length_ratio=0.9,
@@ -93,7 +93,7 @@ def test_butterworth_line_cpu_gpu_equiv():
         xp=np,
     )
     line_gpu = butterworth_line(
-        shape=(512, 512),
+        shape=(512, 511),
         width=3,
         sb_position=(100.1, 100),
         length_ratio=0.9,

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -71,8 +71,8 @@ def test_butterworth_disk_cpu_gpu_equiv():
         pytest.skip("No CUDA device or no CuPy, skipping CuPy test")
 
     import cupy as cp
-    disk_gpu = butterworth_disk(shape=(4096, 4096), radius=128.0, order=12, xp=cp)
-    disk_cpu = butterworth_disk(shape=(4096, 4096), radius=128.0, order=12, xp=np)
+    disk_gpu = butterworth_disk(shape=(512, 512), radius=128.0, order=12, xp=cp)
+    disk_cpu = butterworth_disk(shape=(512, 512), radius=128.0, order=12, xp=np)
 
     assert np.allclose(disk_gpu.get(), disk_cpu)
 
@@ -85,7 +85,7 @@ def test_butterworth_line_cpu_gpu_equiv():
     import cupy as cp
 
     line_cpu = butterworth_line(
-        shape=(4096, 4096),
+        shape=(512, 512),
         width=3,
         sb_position=(100.1, 100),
         length_ratio=0.9,
@@ -93,7 +93,7 @@ def test_butterworth_line_cpu_gpu_equiv():
         xp=np,
     )
     line_gpu = butterworth_line(
-        shape=(4096, 4096),
+        shape=(512, 512),
         width=3,
         sb_position=(100.1, 100),
         length_ratio=0.9,

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -4,6 +4,7 @@ import numpy as np
 from libertem.utils.devices import detect
 
 from libertem_holo.base.utils import HoloParams
+from libertem_holo.base.reconstr import phase_offset_correction
 
 
 @pytest.mark.parametrize(
@@ -38,7 +39,6 @@ def test_holo_params_happy_case(backend: str, holo_data) -> None:
     assert p2.sb_position_int == (53, 58)
 
 
-@pytest.mark.skip
 @pytest.mark.parametrize(
     "backend", ["numpy", "cupy"],
 )
@@ -54,13 +54,9 @@ def test_phase_offset_happy_case(backend: str, holo_data) -> None:
     else:
         xp = np
 
-    _ = HoloParams.from_hologram(
-        ref[0, 0],
-        central_band_mask_radius=1,
-        out_shape=(64, 64),
-        line_filter_length=0.9,
-        line_filter_width=2,
-        xp=xp,
-    )
+    phase_ref = xp.asarray(phase_ref)
 
-    raise NotImplementedError("TODO: make up a test case for phase offset correction")
+    phase_offset_correction(
+        phase_ref.reshape((-1, phase_ref.shape[2], phase_ref.shape[3])),
+        xp=xp
+    )

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -36,3 +36,31 @@ def test_holo_params_happy_case(backend: str, holo_data) -> None:
     p2 = p.filter_aperture_gaussian(sigma=1)
 
     assert p2.sb_position_int == (53, 58)
+
+
+@pytest.mark.skip
+@pytest.mark.parametrize(
+    "backend", ["numpy", "cupy"],
+)
+def test_phase_offset_happy_case(backend: str, holo_data) -> None:
+    holo, ref, phase_ref, slice_crop = holo_data
+
+    if backend == "cupy":
+        d = detect()
+        if not d["cudas"] or not d["has_cupy"]:
+            pytest.skip("No CUDA device or no CuPy, skipping CuPy test")
+        import cupy as cp
+        xp = cp
+    else:
+        xp = np
+
+    _ = HoloParams.from_hologram(
+        ref[0, 0],
+        central_band_mask_radius=1,
+        out_shape=(64, 64),
+        line_filter_length=0.9,
+        line_filter_width=2,
+        xp=xp,
+    )
+
+    raise NotImplementedError("TODO: make up a test case for phase offset correction")

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -60,3 +60,22 @@ def test_phase_offset_happy_case(backend: str, holo_data) -> None:
         phase_ref.reshape((-1, phase_ref.shape[2], phase_ref.shape[3])),
         xp=xp
     )
+
+
+@pytest.mark.parametrize(
+    "backend", ["numpy", "cupy"],
+)
+def test_hard_aperture_disk_non_square(backend: str) -> None:
+    if backend == "cupy":
+        d = detect()
+        if not d["cudas"] or not d["has_cupy"]:
+            pytest.skip("No CUDA device or no CuPy, skipping CuPy test")
+        import cupy as cp
+        xp = cp
+    else:
+        xp = np
+
+    from libertem_holo.base.utils import _hard_disk_aperture
+
+    aperture = _hard_disk_aperture((512, 511), radius=7, xp=xp)
+    assert aperture.shape == (512, 511)


### PR DESCRIPTION
Make sure not only the reconstruction is fast, but also the auxiliary functions, like those that build apertures etc. There might be some functions that still need to have CUDA/cupy support added.

## Changes

* Add benchmarks for aperture generation and parameter estimation
* Add CUDA or cupy implementations for `butterworth_disk`, `butterworth_line`, `freq_array`

* Add an additional sped up `_hard_disk_aperture` function with cupy support, that is used in `estimate_sideband_position`
* Make sure `estimate_sideband_position` properly puts the work onto the GPU if requested
* Add tests that make sure the GPU implementations give equivalent results (not sampling the parameter space very widely, but still...)
* Add smoke test `test_phase_offset_happy_case`  for phase offset correction; ensure `cupy` support
* Use `numba` to parallelize also in the CPU case (as apertures are often built and inspected on the main Python process, before the parallel reconstruction work starts)

## Benchmark results (whole suite; AMD EPYC 7F72 / RTX 3090; see below comments for updated benchmarks):

| Name (time in ms)                   | Min                 | Max                | Mean            | StdDev              | Median               |
|-------------------------------------|---------------------|--------------------|-----------------|---------------------|----------------------|
| test_butterworth_disk[cupy]          | 21.4233 (1.0)       | 21.7230 (1.0)      | 21.5623 (1.0)     | 0.1227 (2.38)       | 21.5440 (1.0)        |
| test_butterworth_line[cupy]          | 25.5878 (1.19)      | 25.7348 (1.18)      | 25.6351 (1.19)     | 0.0516 (1.0)        | 25.6246 (1.19)      |
| test_butterworth_disk[numpy]        | 478.8928 (22.35)    | 479.0459 (22.05)    | 478.9453 (22.21)   | 0.0596 (1.16)       | 478.9243 (22.23)     |
| test_butterworth_line[numpy]        | 504.4176 (23.55)    | 505.1601 (23.25)    | 504.7073 (23.41)   | 0.2992 (5.80)       | 504.5781 (23.42)     |
| test_disk_aperture[cupy]            | 883.2820 (41.23)    | 887.0135 (40.83)    | 884.6027 (41.03)   | 1.5269 (29.60)      | 883.9387 (41.03)     |
| test_disk_aperture[numpy]           | 899.6360 (41.99)    | 900.9193 (41.47)    | 900.1738 (41.75)   | 0.5638 (10.93)      | 900.0594 (41.78)     |
| test_stack_reconstr[cupy]            | 157.9966 (1.0)      | 174.8154 (1.0)      | 161.5232 (1.0)     | 6.5347 (1.0)        | 159.1098 (1.0)      |
| test_stack_reconstr[numpy]          | 3,316.6887 (20.99)  | 3,341.0122 (19.11)  | 3,326.0300 (20.59) | 9.1229 (1.40)       | 3,323.3022 (20.89)   |
| test_params_from_hologram[cupy]      | 40.8912 (1.0)       | 45.8550 (1.0)       | 42.5200 (1.0)     | 2.2139 (1.03)       | 41.0621 (1.0)        |
| test_params_from_hologram[numpy]    | 2,952.0524 (72.19)  | 2,957.7300 (64.50)  | 2,954.9798 (69.50) | 2.1494 (1.0)        | 2,954.6557 (71.96)   |

## Contributor Checklist:

* [ ] I have added myself to [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases

<!--

## Please remove this section

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
