### PR TITLE
phase_offset_correction: fix for R<=2

### DIFF
--- a/src/libertem_holo/base/reconstr.py
+++ b/src/libertem_holo/base/reconstr.py
@@ -432,6 +432,17 @@ def phase_offset_correction(
         Either numpy or cupy for GPU support
     """
     R = aligned_stack.shape[0]
+    orig_R = R
+
+    # Otherwise eigsh is unhappy
+    if R <= 2:
+        # Not sure how broadcasting works here, but try to be equivalent
+        new_shape = (3,) + aligned_stack.shape[1:]
+        new_aligned_stack = np.zeros_like(aligned_stack, shape=new_shape)
+        new_aligned_stack[:R, :, :] = aligned_stack
+        R = 3
+        aligned_stack = new_aligned_stack
+
     ph_diff = xp.zeros((R, R), dtype=complex)
     d1 = aligned_stack.shape[1]
     d2 = aligned_stack.shape[2]
@@ -472,6 +483,6 @@ def phase_offset_correction(
     result[mask] = result[mask] / count[mask]
 
     if return_stack:
-        return result, result_stack
+        return result, result_stack[:orig_R]
     else:
         return result, None


### PR DESCRIPTION
Stolen from @uellue here:
https://github.com/Ptychography-4-0/ptychography/pull/72/files#diff-e1be99d3d23dff74d631c81d3e89da2a3492218930871d39a001703b42ff17b7R65

Adds a minimal test case

## Contributor Checklist:

* [ ] I have added myself to [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases

<!--

## Please remove this section

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
