### PR TITLE
Small bugfixes/QoL

### DIFF
--- a/src/libertem_holo/base/reconstr.py
+++ b/src/libertem_holo/base/reconstr.py
@@ -431,6 +431,7 @@ def phase_offset_correction(
     xp
         Either numpy or cupy for GPU support
     """
+    aligned_stack = xp.asarray(aligned_stack)
     R = aligned_stack.shape[0]
     orig_R = R
 

--- a/src/libertem_holo/base/utils.py
+++ b/src/libertem_holo/base/utils.py
@@ -230,7 +230,7 @@ class HoloParams(typing.NamedTuple):
         cls,
         hologram: np.ndarray,
         *,
-        central_band_mask_radius: int,
+        central_band_mask_radius: float | None = None,
         out_shape: tuple = None,
         line_filter_length: float = 0.9,
         line_filter_width: float | None = 20,

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -145,7 +145,13 @@ def test_phase_offset(backend: str, holo_data, lt_ctx) -> None:
 
     w_holo = w_holo.reshape((-1,) + tuple(out_shape))
 
-    # pick two holograms and align the phase offset:
+    # pick two holograms and align the phase offset
+    # (in case of cupy, input data is implicitly moved to device):
     averaged, stack = phase_offset_correction(
         w_holo[:2], return_stack=True, xp=xp,
+    )
+
+    # with explicit conversion it should still work:
+    averaged, stack = phase_offset_correction(
+        xp.asarray(w_holo[:2]), return_stack=True, xp=xp,
     )


### PR DESCRIPTION
- `HoloParams.from_hologram`: make `central_band_mask_radius` optional
- `phase_offset_correction`: implicit conversion to `cupy` array; meaning `xp==cp` and `type(aligned_stack) == np.ndarray` works now

## Contributor Checklist:

* [ ] I have added myself to [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases

<!--

## Please remove this section

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
